### PR TITLE
14 add/turbo

### DIFF
--- a/app/controllers/curious_lists_controller.rb
+++ b/app/controllers/curious_lists_controller.rb
@@ -2,16 +2,24 @@ class CuriousListsController < ApplicationController
   before_action :require_login
 
   def create
-    event = Event.find(params[:event_id])
-    CuriousList.find_or_create_by(user: current_user, event: event)
-    redirect_back fallback_location: events_path, notice: "気になるに追加しました"
+    @event = Event.find(params[:event_id])
+    CuriousList.find_or_create_by(user: current_user, event: @event)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: events_path, notice: "気になるに追加しました" }
+    end
   end
 
   def destroy
-    event = Event.find(params[:event_id])
-    curious = CuriousList.find_by(user: current_user, event: event)
+    @event = Event.find(params[:event_id])
+    curious = CuriousList.find_by(user: current_user, event: @event)
     curious&.destroy
-    redirect_back fallback_location: events_path, notice: "気になるを解除しました"
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: events_path, notice: "気になるを解除しました" }
+    end
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,6 @@
 class EventsController < ApplicationController
   before_action :set_event, only: %i[ show edit update destroy ]
   before_action :require_login
-  before_action :store_return_path, only: %i[index participating interested]
-  before_action :load_return_path, only: [ :show ]
 
   def index
     @events = current_user.demo? ? Event.demo_visible_to(current_user) : Event.exclude_demo_users
@@ -59,6 +57,7 @@ class EventsController < ApplicationController
   end
 
 private
+
   def set_event
     @event = Event.find(params[:id])
   end
@@ -68,18 +67,6 @@ private
   end
 
   def require_login
-    unless current_user
-      redirect_to root_path, alert: "ログインが必要です"
-    end
-  end
-
-  def store_return_path
-    if request.referer.present? && URI(request.referer).host == request.host
-      cookies[:return_to] = request.fullpath
-    end
-  end
-
-  def load_return_path
-    @return_to = cookies[:return_to]
+    redirect_to root_path, alert: "ログインが必要です" unless current_user
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,8 @@
 class EventsController < ApplicationController
   before_action :set_event, only: %i[ show edit update destroy ]
   before_action :require_login
+  before_action :store_return_path, only: %i[index participating interested]
+  before_action :load_return_path, only: [:show]
 
   def index
     @events = current_user.demo? ? Event.demo_visible_to(current_user) : Event.exclude_demo_users
@@ -69,5 +71,15 @@ private
     unless current_user
       redirect_to root_path, alert: "ログインが必要です"
     end
+  end
+
+  def store_return_path
+    if request.referer.present? && URI(request.referer).host == request.host
+      cookies[:return_to] = request.fullpath
+    end
+  end
+
+  def load_return_path
+    @return_to = cookies[:return_to]
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :set_event, only: %i[ show edit update destroy ]
   before_action :require_login
   before_action :store_return_path, only: %i[index participating interested]
-  before_action :load_return_path, only: [:show]
+  before_action :load_return_path, only: [ :show ]
 
   def index
     @events = current_user.demo? ? Event.demo_visible_to(current_user) : Event.exclude_demo_users

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -2,25 +2,39 @@ class ParticipantsController < ApplicationController
   before_action :require_login
 
   def create
-    event = Event.find(params[:event_id])
+    @event = Event.find(params[:event_id])
 
-    if event.participant_users.exists?(current_user.id)
-      redirect_to events_path, alert: "すでに参加済みです"
+    if @event.participant_users.exists?(current_user.id)
+      respond_to do |format|
+        format.turbo_stream { head :conflict }
+        format.html { redirect_to events_path, alert: "すでに参加済みです" }
+      end
     else
-      Participant.create!(user: current_user, event: event)
-      redirect_to events_path, notice: "イベントに参加しました！"
+      Participant.create!(user: current_user, event: @event)
+
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to events_path, notice: "イベントに参加しました！" }
+      end
     end
   end
 
   def destroy
-    event = Event.find(params[:event_id])
-    participant = Participant.find_by(user: current_user, event: event)
+    @event = Event.find(params[:event_id])
+    participant = Participant.find_by(user: current_user, event: @event)
 
     if participant
       participant.destroy
-      redirect_to events_path, notice: "参加をキャンセルしました"
+
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to events_path, notice: "参加をキャンセルしました" }
+      end
     else
-      redirect_to events_path, alert: "参加情報が見つかりません"
+      respond_to do |format|
+        format.turbo_stream { head :not_found }
+        format.html { redirect_to events_path, alert: "参加情報が見つかりません" }
+      end
     end
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -73,4 +73,17 @@ module EventsHelper
   def tag_color(_tag_name)
     "6c757d"  # Bootstrap風のグレー
   end
+
+  def safe_return_to_path
+    return_to = params[:return_to]
+
+    # ホスト名を含まない相対パスだけを許可
+    if return_to.present? && URI.parse(return_to).host.nil?
+      return_to
+    else
+      events_path
+    end
+  rescue URI::InvalidURIError
+    events_path
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -16,30 +16,46 @@ module EventsHelper
   end
 
   def participation_button(event, user)
-    if user_joined?(event, user)
-      button_to "キャンセル",
-                event_participant_path(event),
-                method: :delete,
-                class: base_button_class + " bg-gray-400 hover:bg-gray-500"
-    else
-      button_to "参加",
-                event_participant_path(event),
-                method: :post,
-                class: base_button_class + " bg-orange-500 hover:bg-orange-400"
+    turbo_frame_tag dom_id(event, :participation_button) do
+      if user_joined?(event, user)
+        button_to "キャンセル",
+                  event_participant_path(event),
+                  method: :delete,
+                  form: { data: { turbo_stream: true } },
+                  class: base_button_class + " bg-gray-400 hover:bg-gray-500"
+      else
+        button_to "参加",
+                  event_participant_path(event),
+                  method: :post,
+                  form: { data: { turbo_stream: true } },
+                  class: base_button_class + " bg-orange-500 hover:bg-orange-400"
+      end
+    end
+  end
+
+  def participation_count(event)
+    turbo_frame_tag dom_id(event, :participant_count) do
+      content_tag :p, class: "text-sm text-gray-600" do
+        raw "<i class='fas fa-users mr-1'></i>#{joined_count(event)}名 / #{event.capacity.present? ? "#{event.capacity}名" : "制限なし"}"
+      end
     end
   end
 
   def curious_button(event, user)
-    if user_curious?(event, user)
-      button_to "気になる解除",
-                event_curious_list_path(event),
-                method: :delete,
-                class: base_button_class(margin: true) + " bg-gray-400 hover:bg-gray-500"
-    else
-      button_to "気になる",
-                event_curious_list_path(event),
-                method: :post,
-                class: base_button_class(margin: true) + " bg-yellow-500 hover:bg-yellow-400"
+    turbo_frame_tag "curious_button_#{event.id}" do
+      if user_curious?(event, user)
+        button_to "気になる解除",
+                  event_curious_list_path(event),
+                  method: :delete,
+                  form: { data: { turbo_stream: true } },
+                  class: base_button_class(margin: true) + " bg-gray-400 hover:bg-gray-500"
+      else
+        button_to "気になる",
+                  event_curious_list_path(event),
+                  method: :post,
+                  form: { data: { turbo_stream: true } },
+                  class: base_button_class(margin: true) + " bg-yellow-500 hover:bg-yellow-400"
+      end
     end
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -19,7 +19,7 @@ module EventsHelper
     turbo_frame_tag dom_id(event, :participation_button) do
       if user_joined?(event, user)
         button_to "キャンセル",
-                  event_participant_path(event),
+                  event_participant_path(event, from: "participating"),
                   method: :delete,
                   form: { data: { turbo_stream: true } },
                   class: base_button_class + " bg-gray-400 hover:bg-gray-500"
@@ -45,7 +45,7 @@ module EventsHelper
     turbo_frame_tag "curious_button_#{event.id}" do
       if user_curious?(event, user)
         button_to "気になる解除",
-                  event_curious_list_path(event),
+                  event_curious_list_path(event, from: "interested"),
                   method: :delete,
                   form: { data: { turbo_stream: true } },
                   class: base_button_class(margin: true) + " bg-gray-400 hover:bg-gray-500"

--- a/app/views/curious_lists/create.turbo_stream.erb
+++ b/app/views/curious_lists/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "curious_button_#{@event.id}" do %>
+  <%= curious_button(@event, current_user) %>
+<% end %>

--- a/app/views/curious_lists/destroy.turbo_stream.erb
+++ b/app/views/curious_lists/destroy.turbo_stream.erb
@@ -1,3 +1,13 @@
 <%= turbo_stream.replace "curious_button_#{@event.id}" do %>
   <%= curious_button(@event, current_user) %>
 <% end %>
+
+<% if params[:from] == "interested" %>
+  <%= turbo_stream.remove dom_id(@event, :card) %>
+
+  <% if current_user.curious_events.reload.empty? %>
+    <%= turbo_stream.append "events_list" do %>
+      <%= content_tag(:p, "気になるイベントはまだありません", class: "text-center text-lg text-gray-600") %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/curious_lists/destroy.turbo_stream.erb
+++ b/app/views/curious_lists/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "curious_button_#{@event.id}" do %>
+  <%= curious_button(@event, current_user) %>
+<% end %>

--- a/app/views/events/_event_card.html.erb
+++ b/app/views/events/_event_card.html.erb
@@ -1,7 +1,7 @@
-<div class="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+<div id="events_list" class="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
   <% if events.any? %>
     <% events.each do |event| %>
-      <div class="relative bg-white shadow-md rounded-lg overflow-hidden hover:shadow-xl transition duration-300 <%= 'opacity-50' if event_full?(event) %>">
+      <div id="<%= dom_id(event, :card) %>" class="relative bg-white shadow-md rounded-lg overflow-hidden hover:shadow-xl transition duration-300 <%= 'opacity-50' if event_full?(event) %>">
         <%= link_to event_path(event) do %>
           <div class="p-4 flex gap-4">
             <div>

--- a/app/views/events/_event_card.html.erb
+++ b/app/views/events/_event_card.html.erb
@@ -2,7 +2,7 @@
   <% if events.any? %>
     <% events.each do |event| %>
       <div id="<%= dom_id(event, :card) %>" class="relative bg-white shadow-md rounded-lg overflow-hidden hover:shadow-xl transition duration-300 <%= 'opacity-50' if event_full?(event) %>">
-        <%= link_to event_path(event) do %>
+        <%= link_to event_path(event, return_to: request.fullpath) do %>
           <div class="p-4 flex gap-4">
             <div>
               <%= image_tag event.host_user.profile_picture, alt: event.host_user.name, class: "w-14 h-14 rounded-full border border-gray-300" %>

--- a/app/views/events/_event_card.html.erb
+++ b/app/views/events/_event_card.html.erb
@@ -26,7 +26,7 @@
 
               <div class="flex justify-between text-xs text-gray-500 mt-2">
                 <span><i class="fas fa-hourglass-half mr-1"></i><%= event.deadline&.strftime('%Y-%m-%d') %></span>
-                <span><i class="fas fa-users mr-1"></i><%= joined_count(event) %>名 / <%= event.capacity.present? ? "#{event.capacity}名" : "制限なし" %></span>
+                <%= participation_count(event) %>
               </div>
             </div>
           </div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -4,5 +4,7 @@
 <%= render 'form' %>
 
 <div class="text-center mt-4">
-  <%= link_to t('edit.back_to_show'), event_path(@event, return_to: params[:return_to]), class: "text-blue-500 hover:underline" %>
+  <%= link_to t('edit.back_to_show'),
+              event_path(@event, return_to: safe_return_to_path),
+              class: "text-blue-500 hover:underline" %>
 </div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -4,5 +4,5 @@
 <%= render 'form' %>
 
 <div class="text-center mt-4">
-  <%= link_to t('edit.back_to_show'), event_path(@event), class: "text-blue-500 hover:underline" %>
+  <%= link_to t('edit.back_to_show'), event_path(@event, return_to: params[:return_to]), class: "text-blue-500 hover:underline" %>
 </div>

--- a/app/views/events/participating.html.erb
+++ b/app/views/events/participating.html.erb
@@ -5,20 +5,17 @@
 
   <!-- タブ切り替え -->
   <div class="flex space-x-4 mb-6">
-    <button data-tab="hosted"
-      class="tab-btn px-4 py-2 rounded-full font-semibold transition"
-      aria-selected="false">
-      企画イベント
-    </button>
-    <button data-tab="joined"
-      class="tab-btn px-4 py-2 bg-blue-200 text-blue-800 rounded-full font-semibold transition"
-      aria-selected="true">
-      参加イベント
-    </button>
+    <%= link_to "企画イベント", participating_events_path(tab: "hosted"),
+      class: "tab-btn px-4 py-2 rounded-full font-semibold transition #{params[:tab] == 'hosted' ? 'bg-pink-200 text-pink-800' : ''}",
+      "aria-selected": params[:tab] == 'hosted' %>
+
+    <%= link_to "参加イベント", participating_events_path(tab: "joined"),
+      class: "tab-btn px-4 py-2 rounded-full font-semibold transition #{params[:tab] != 'hosted' ? 'bg-blue-200 text-blue-800' : ''}",
+      "aria-selected": params[:tab] != 'hosted' %>
   </div>
 
   <!-- コンテンツ -->
-  <div id="hosted" class="tab-content hidden">
+  <% if params[:tab] == 'hosted' %>
     <%= render partial: "event_card", locals: {
       events: @hosted_events,
       current_user: current_user,
@@ -26,9 +23,7 @@
       show_curious_button: false,
       empty_message: "企画中のイベントはありません。"
     } %>
-  </div>
-
-  <div id="joined" class="tab-content block">
+  <% else %>
     <%= render partial: "event_card", locals: {
       events: @joined_events,
       current_user: current_user,
@@ -36,40 +31,5 @@
       show_curious_button: true,
       empty_message: "参加中のイベントはありません。"
     } %>
-  </div>
+  <% end %>
 </div>
-
-<script>
-  document.addEventListener("turbo:load", () => {
-    const tabButtons = document.querySelectorAll(".tab-btn");
-    const tabContents = document.querySelectorAll(".tab-content");
-
-    const updateTabs = (activeBtn) => {
-      tabButtons.forEach((btn) => {
-        btn.classList.remove("bg-pink-200", "text-pink-800", "bg-blue-200", "text-blue-800");
-        btn.setAttribute("aria-selected", "false");
-      });
-
-      const tab = activeBtn.dataset.tab;
-      if (tab === "hosted") {
-        activeBtn.classList.add("bg-pink-200", "text-pink-800");
-      } else if (tab === "joined") {
-        activeBtn.classList.add("bg-blue-200", "text-blue-800");
-      }
-      activeBtn.setAttribute("aria-selected", "true");
-
-      tabContents.forEach((content) => {
-        content.classList.toggle("hidden", content.id !== tab);
-      });
-    };
-
-    // イベントを再登録
-    tabButtons.forEach((btn) => {
-      btn.addEventListener("click", () => updateTabs(btn));
-    });
-
-    // 初期表示（参加イベント）を選択状態に
-    const initialTab = Array.from(tabButtons).find(btn => btn.dataset.tab === "joined");
-    if (initialTab) updateTabs(initialTab);
-  });
-</script>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -55,11 +55,11 @@
 
           <%= button_to t('buttons.delete'), @event, method: :delete, data: { confirm: t('events.confirm_delete') }, class: "bg-red-600 hover:bg-red-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
 
-          <%= link_to t('buttons.back'), @return_to || events_path, class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t("buttons.back"), url_for(cookies[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
         </div>
       <% else %>
         <div class="text-right mt-6">
-          <%= link_to t('buttons.back'), @return_to || events_path, class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t("buttons.back"), url_for(cookies[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
         </div>
       <% end %>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -51,15 +51,15 @@
       <!-- 編集・削除・戻るボタン -->
       <% if @event.host_user == current_user %>
         <div class="flex justify-between mt-6">
-          <%= link_to t('buttons.edit'), edit_event_path(@event, return_to: @return_to), class: "bg-blue-600 hover:bg-blue-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t('buttons.edit'), edit_event_path(@event, return_to: request.fullpath), class: "bg-blue-600 hover:bg-blue-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
 
           <%= button_to t('buttons.delete'), @event, method: :delete, data: { confirm: t('events.confirm_delete') }, class: "bg-red-600 hover:bg-red-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
 
-          <%= link_to t("buttons.back"), url_for(cookies[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t("buttons.back"), (params[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
         </div>
       <% else %>
         <div class="text-right mt-6">
-          <%= link_to t("buttons.back"), url_for(cookies[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t("buttons.back"), (params[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
         </div>
       <% end %>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,3 @@
-<!-- app/views/events/show.html.erb -->
-
 <% content_for :title, @event.title %>
 
 <div class="container mx-auto px-4 py-8">
@@ -33,7 +31,7 @@
 
       <!-- 参加人数 -->
       <div class="flex justify-between text-sm text-gray-600 mb-4">
-        <p><i class="fas fa-users"></i> 2名 / <%= @event.capacity %>名</p>
+        <%= participation_count(@event) %>
       </div>
 
       <!-- イベント詳細説明 -->
@@ -45,7 +43,7 @@
       <!-- 参加する・気になるボタン -->
       <div class="p-4 bg-gray-100 text-center">
         <%= participation_button(@event, current_user) %>
-<%= curious_button(@event, current_user) %>
+        <%= curious_button(@event, current_user) %>
       </div>
 
       <!-- 編集、削除、戻るボタン -->

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,7 +29,7 @@
         </div>
       <% end %>
 
-      <!-- 参加人数 -->
+      <!-- 参加人数（Turbo対応） -->
       <div class="flex justify-between text-sm text-gray-600 mb-4">
         <%= participation_count(@event) %>
       </div>
@@ -40,20 +40,28 @@
         <p class="text-gray-700"><%= @event.description %></p>
       </div>
 
-      <!-- 参加する・気になるボタン -->
-      <div class="p-4 bg-gray-100 text-center">
-        <%= participation_button(@event, current_user) %>
-        <%= curious_button(@event, current_user) %>
-      </div>
+      <!-- 参加する・気になるボタン（Turbo対応） -->
+      <% unless @event.host_user == current_user %>
+        <div class="p-4 bg-gray-100 text-center">
+          <%= participation_button(@event, current_user) %>
+          <%= curious_button(@event, current_user) %>
+        </div>
+      <% end %>
 
-      <!-- 編集、削除、戻るボタン -->
-      <div class="flex justify-between mt-6">
-        <%= link_to t('buttons.edit'), edit_event_path(@event), class: "bg-blue-600 hover:bg-blue-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
-        
-        <%= button_to t('buttons.delete'), @event, method: :delete, data: { confirm: t('events.confirm_delete') }, class: "bg-red-600 hover:bg-red-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+      <!-- 編集・削除・戻るボタン -->
+      <% if @event.host_user == current_user %>
+        <div class="flex justify-between mt-6">
+          <%= link_to t('buttons.edit'), edit_event_path(@event, return_to: @return_to), class: "bg-blue-600 hover:bg-blue-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
 
-        <%= link_to t('buttons.back'), events_path, class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
-      </div>
+          <%= button_to t('buttons.delete'), @event, method: :delete, data: { confirm: t('events.confirm_delete') }, class: "bg-red-600 hover:bg-red-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+
+          <%= link_to t('buttons.back'), @return_to || events_path, class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+        </div>
+      <% else %>
+        <div class="text-right mt-6">
+          <%= link_to t('buttons.back'), @return_to || events_path, class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -51,15 +51,25 @@
       <!-- 編集・削除・戻るボタン -->
       <% if @event.host_user == current_user %>
         <div class="flex justify-between mt-6">
-          <%= link_to t('buttons.edit'), edit_event_path(@event, return_to: request.fullpath), class: "bg-blue-600 hover:bg-blue-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t('buttons.edit'),
+                      edit_event_path(@event, return_to: request.fullpath),
+                      class: "bg-blue-600 hover:bg-blue-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
 
-          <%= button_to t('buttons.delete'), @event, method: :delete, data: { confirm: t('events.confirm_delete') }, class: "bg-red-600 hover:bg-red-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= button_to t('buttons.delete'),
+                        @event,
+                        method: :delete,
+                        data: { confirm: t('events.confirm_delete') },
+                        class: "bg-red-600 hover:bg-red-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
 
-          <%= link_to t("buttons.back"), (params[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t("buttons.back"),
+                      safe_return_to_path,
+                      class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
         </div>
       <% else %>
         <div class="text-right mt-6">
-          <%= link_to t("buttons.back"), (params[:return_to] || events_path), class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
+          <%= link_to t("buttons.back"),
+                      safe_return_to_path,
+                      class: "bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition duration-300" %>
         </div>
       <% end %>
     </div>

--- a/app/views/participants/create.turbo_stream.erb
+++ b/app/views/participants/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace dom_id(@event, :participation_button) do %>
+  <%= participation_button(@event, current_user) %>
+<% end %>
+
+<%= turbo_stream.replace dom_id(@event, :participant_count) do %>
+  <%= participation_count(@event) %>
+<% end %>

--- a/app/views/participants/destroy.turbo_stream.erb
+++ b/app/views/participants/destroy.turbo_stream.erb
@@ -5,3 +5,13 @@
 <%= turbo_stream.replace dom_id(@event, :participant_count) do %>
   <%= participation_count(@event) %>
 <% end %>
+
+<% if request.referrer&.include?(participating_events_path) && (params[:from] == "participating") %>
+  <%= turbo_stream.remove dom_id(@event, :card) %>
+
+  <% if current_user.joined_events.reload.empty? %>
+    <%= turbo_stream.append "events_list" do %>
+      <%= content_tag(:p, "参加中のイベントはありません。", class: "text-center text-lg text-gray-600") %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/participants/destroy.turbo_stream.erb
+++ b/app/views/participants/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace dom_id(@event, :participation_button) do %>
+  <%= participation_button(@event, current_user) %>
+<% end %>
+
+<%= turbo_stream.replace dom_id(@event, :participant_count) do %>
+  <%= participation_count(@event) %>
+<% end %>


### PR DESCRIPTION
## 概要

- [x] Turboでの非同期通信「参加」「気になる」ボタン
- [x] 「企画・参加リスト」「気になるリスト」からevents#showに遷移して、また一覧に戻る際、前に滞在した一覧に戻るように設定
- [x] 「企画・参加リスト」において、参加解除をした場合にリストから消えるようにする。
- [x] 「気になるリスト」において、気になる解除をした場合にリストから消えるようにする。

## 関連issue
- https://github.com/Manabe-K/choi_atsu/issues/25